### PR TITLE
fix: Ignore packages that are not plugins

### DIFF
--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -1,24 +1,32 @@
 import importlib
-import logging
 import pkgutil
-from typing import Dict, Type
+import warnings
+from pathlib import Path
+from typing import Dict, Iterable, Type
 
 from commitizen.cz.base import BaseCommitizen
 from commitizen.cz.conventional_commits import ConventionalCommitsCz
 from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.cz.jira import JiraSmartCz
 
-logger = logging.getLogger(__name__)
 
+def discover_plugins(path: Iterable[Path] = None) -> Dict[str, Type[BaseCommitizen]]:
+    """Discover commitizen plugins on the path
 
-def discover_plugins():
+    Args:
+        path (Path, optional): If provided, 'path' should be either None or a list of paths to look for
+    modules in. If path is None, all top-level modules on sys.path.. Defaults to None.
+
+    Returns:
+        Dict[str, Type[BaseCommitizen]]: Registry with found plugins
+    """
     plugins = {}
-    for finder, name, ispkg in pkgutil.iter_modules():
+    for finder, name, ispkg in pkgutil.iter_modules(path):
         try:
             if name.startswith("cz_"):
                 plugins[name] = importlib.import_module(name).discover_this
         except AttributeError as e:
-            logger.warning(e.args[0])
+            warnings.warn(UserWarning(e.args[0]))
             continue
     return plugins
 

--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -1,14 +1,15 @@
 import importlib
 import logging
 import pkgutil
-
 from typing import Dict, Type
+
 from commitizen.cz.base import BaseCommitizen
 from commitizen.cz.conventional_commits import ConventionalCommitsCz
 from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.cz.jira import JiraSmartCz
 
 logger = logging.getLogger(__name__)
+
 
 def discover_plugins():
     plugins = {}
@@ -20,6 +21,7 @@ def discover_plugins():
             logger.warning(e.args[0])
             continue
     return plugins
+
 
 registry: Dict[str, Type[BaseCommitizen]] = {
     "cz_conventional_commits": ConventionalCommitsCz,

--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -1,21 +1,30 @@
 import importlib
+import logging
 import pkgutil
-from typing import Dict, Type
 
+from typing import Dict, Type
 from commitizen.cz.base import BaseCommitizen
 from commitizen.cz.conventional_commits import ConventionalCommitsCz
 from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.cz.jira import JiraSmartCz
+
+logger = logging.getLogger(__name__)
+
+def discover_plugins():
+    plugins = {}
+    for finder, name, ispkg in pkgutil.iter_modules():
+        try:
+            if name.startswith("cz_"):
+                plugins[name] = importlib.import_module(name).discover_this
+        except AttributeError as e:
+            logger.warning(e.args[0])
+            continue
+    return plugins
 
 registry: Dict[str, Type[BaseCommitizen]] = {
     "cz_conventional_commits": ConventionalCommitsCz,
     "cz_jira": JiraSmartCz,
     "cz_customize": CustomizeCommitsCz,
 }
-plugins = {
-    name: importlib.import_module(name).discover_this  # type: ignore
-    for finder, name, ispkg in pkgutil.iter_modules()
-    if name.startswith("cz_")
-}
 
-registry.update(plugins)
+registry.update(discover_plugins())

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,7 +1,10 @@
+import sys
+
 import pytest
 
 from commitizen import BaseCommitizen, defaults, factory
 from commitizen.config import BaseConfig
+from commitizen.cz import discover_plugins
 from commitizen.exceptions import NoCommitizenFoundException
 
 
@@ -19,3 +22,27 @@ def test_factory_fails():
         factory.commiter_factory(config)
 
     assert "The committer has not been found in the system." in str(excinfo)
+
+
+@pytest.mark.parametrize(
+    "module_content, plugin_name, expected_plugins",
+    [
+        ("", "cz_no_plugin", {}),
+    ],
+)
+def test_discover_plugins(module_content, plugin_name, expected_plugins, tmp_path):
+    no_plugin_folder = tmp_path / plugin_name
+    no_plugin_folder.mkdir()
+    init_file = no_plugin_folder / "__init__.py"
+    init_file.write_text(module_content)
+
+    sys.path.append(tmp_path.as_posix())
+    with pytest.warns(UserWarning) as record:
+        discovered_plugins = discover_plugins([tmp_path])
+    sys.path.pop()
+
+    assert (
+        record[0].message.args[0]
+        == f"module '{plugin_name}' has no attribute 'discover_this'"
+    )
+    assert expected_plugins == discovered_plugins


### PR DESCRIPTION
When a package starting with a plugin name is found, but it is not a plugin, it becomes safely ignored.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
When a packages has a name that matches a plugin, but it is not a plugin, it is safely ignored and reported to the user.

Background: The company where I work, and where I use `commitizen` for releasing package versions, is called CZ. And because we are not very imaginative, we use to call the packages that we develop for internal use something like `cz_`.

This collides with the way that `commitizen` discover plugins, and the discovery process raises an exception when a package starts with the name `cz_` is found but is not implemented as a plugin.

This MR proposes a way to ignore those packages that collide in name but are not plugins. This proposal tries to be as agnostic as possible, not very Pythonic, but I am open to suggestions.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
When the CLI searches for plugins, those packages that have a name `cz_` but lack the `discover_this` attribute, will be ignored and the user will get a warning

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. Create a package with a name starting with `cz_`. It can be located under a `src` folder
2. Install `commitizen`
3. Run `commitizen changelog --help`. Without this patch, an exception will be risen.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->